### PR TITLE
Bruk miljø i stede for cluster-navn

### DIFF
--- a/src/App/LoggInn/LoggInn.tsx
+++ b/src/App/LoggInn/LoggInn.tsx
@@ -2,19 +2,25 @@ import React from 'react';
 import Lenke from 'nav-frontend-lenker';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { Ingress, Normaltekst, Systemtittel } from 'nav-frontend-typografi';
-import environment from '../../utils/environment';
 import handshake from './handshake.svg';
 import { TilgangsStyringInfoTekst } from './TilgangsStyringInfoTekst/TilgangsStyringInfoTekst';
 import Brodsmulesti from '../Brodsmulesti/Brodsmulesti';
 import './Logginn.less';
 import EnkelBanner from '../EnkelBanner/EnkelBanner';
+import { gittMiljø } from '../../utils/environment';
 
 export const redirectTilLogin = () => {
-    if (environment.MILJO === 'prod-sbs' || environment.MILJO === 'dev-sbs' || environment.MILJO === 'labs-gcp') {
-        window.location.href = '/arbeidsforhold/redirect-til-login';
-    } else {
+    const kjørerLokalt = gittMiljø({
+        prod: false,
+        dev: false,
+        labs: false,
+        other: true
+    });
+    if (kjørerLokalt) {
         document.cookie = 'selvbetjening-idtoken=0123456789..*; path=/;';
         window.location.href = '/arbeidsforhold/';
+    } else {
+        window.location.href = '/arbeidsforhold/redirect-til-login';
     }
 };
 

--- a/src/App/MineAnsatte/EnkeltArbeidsforhold/EnkeltArbeidsforhold.tsx
+++ b/src/App/MineAnsatte/EnkeltArbeidsforhold/EnkeltArbeidsforhold.tsx
@@ -4,7 +4,7 @@ import { DetaljertArbeidsforhold } from '@navikt/arbeidsforhold';
 import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
 import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 import Chevron from 'nav-frontend-chevron';
-import environment from '../../../utils/environment';
+import { gittMiljø } from '../../../utils/environment';
 import { Arbeidsforhold } from '../../Objekter/ArbeidsForhold';
 import { useSearchParameters } from '../../../utils/UrlManipulation';
 import { BedriftsmenyContext } from '../../BedriftsmenyProvider';
@@ -14,22 +14,16 @@ import EnkeltArbeidsforholdVarselVisning from './EnkeltArbeidsforholdVarselVisni
 import Brodsmulesti from '../../Brodsmulesti/Brodsmulesti';
 import './EnkeltArbeidsforhold.less';
 
-const miljo = () => {
-    if (environment.MILJO === 'prod-sbs') {
-        return 'PROD';
-    }
-    if (environment.MILJO === 'dev-sbs') {
-        return 'DEV';
-    }
-    return 'LOCAL';
-};
+const miljø = gittMiljø<'PROD' | 'DEV' | 'LOCAL'>({
+    prod: 'PROD',
+    dev: 'DEV',
+    other: 'LOCAL',
+});
 
-const apiURL = () => {
-    if (environment.MILJO === 'prod-sbs') {
-        return 'https://arbeidsgiver.nav.no/arbeidsforhold/person/arbeidsforhold-api/arbeidsforholdinnslag/arbeidsgiver/{id}';
-    }
-    return 'https://arbeidsgiver-q.nav.no/arbeidsforhold/person/arbeidsforhold-api/arbeidsforholdinnslag/arbeidsgiver/{id}';
-};
+const apiURL = gittMiljø({
+    prod: 'https://arbeidsgiver.nav.no/arbeidsforhold/person/arbeidsforhold-api/arbeidsforholdinnslag/arbeidsgiver/{id}',
+    other: 'https://arbeidsgiver-q.nav.no/arbeidsforhold/person/arbeidsforhold-api/arbeidsforholdinnslag/arbeidsgiver/{id}'
+});
 
 const EnkeltArbeidsforhold: FunctionComponent = () => {
     const history = useHistory();
@@ -116,11 +110,11 @@ const EnkeltArbeidsforhold: FunctionComponent = () => {
                         </div>
                         <DetaljertArbeidsforhold
                             locale="nb"
-                            miljo={miljo()}
+                            miljo={miljø}
                             navArbeidsforholdId={parseInt(valgtArbeidsforhold.navArbeidsforholdId)}
                             rolle="ARBEIDSGIVER"
                             fnrArbeidstaker={valgtArbeidsforhold.arbeidstaker.offentligIdent}
-                            customApiUrl={apiURL()}
+                            customApiUrl={apiURL}
                             printActivated={true}
                             printName={valgtArbeidsforhold.arbeidstaker.navn}
                             printSSN={valgtArbeidsforhold.arbeidstaker.offentligIdent}

--- a/src/App/amplitudefunksjonerForLogging.ts
+++ b/src/App/amplitudefunksjonerForLogging.ts
@@ -1,5 +1,5 @@
 import amplitude from '../utils/amplitude';
-import environment from '../utils/environment';
+import { environment } from '../utils/environment';
 
 export const loggAntallAnsatte = (antall: number) => {
     let logg = '#arbeidsforhold antall arbeidsforhold: ';

--- a/src/App/lenker.tsx
+++ b/src/App/lenker.tsx
@@ -1,4 +1,4 @@
-import environment from '../utils/environment';
+import { gittMiljø } from '../utils/environment';
 import { alleFeatures } from './FeatureToggleProvider';
 
 const landingsURL = '/arbeidsforhold/';
@@ -45,23 +45,26 @@ export const hentFeatureTogglesLenke = (): string => {
 
 export const linkTilMinSideArbeidsgiver = (orgnr: string) => {
     const orgNrDel = orgnr.length > 0 ? '?bedrift=' + orgnr : '';
-    if (environment.MILJO === 'prod-sbs') {
-        return 'https://arbeidsgiver.nav.no/min-side-arbeidsgiver/' + orgNrDel;
-    } else if (environment.MILJO === 'dev-sbs') {
-        return 'https://arbeidsgiver-q.nav.no/min-side-arbeidsgiver/' + orgNrDel;
-    }
-    return 'https://arbeidsgiver.labs.nais.io/min-side-arbeidsgiver/' + orgNrDel;
+    return gittMiljø({
+        prod: 'https://arbeidsgiver.nav.no/min-side-arbeidsgiver/',
+        dev: 'https://arbeidsgiver-q.nav.no/min-side-arbeidsgiver/',
+        other: 'https://arbeidsgiver.labs.nais.io/min-side-arbeidsgiver/'
+    }) + orgNrDel;
 };
 
 export const linkTilArbeidsforhold = (orgnr: string) => {
     const orgNrDel = orgnr.length > 0 ? '?bedrift=' + orgnr : '';
-    if (environment.MILJO === 'prod-sbs') {
-        return 'https://arbeidsgiver.nav.no/arbeidsforhold/' + orgNrDel;
-    } else if (environment.MILJO === 'dev-sbs') {
-        return 'https://arbeidsgiver-q.nav.no/arbeidsforhold/' + orgNrDel;
-    }
-    return 'https://arbeidsgiver.labs.nais.io/arbeidsforhold/' + orgNrDel;
+    return gittMiljø({
+        prod: 'https://arbeidsgiver.nav.no/arbeidsforhold/',
+        dev: 'https://arbeidsgiver-q.nav.no/arbeidsforhold/',
+        other: 'https://arbeidsgiver.labs.nais.io/arbeidsforhold/',
+    }) + orgNrDel;
 };
+
+const delegationRequestUrl = gittMiljø({
+    prod: 'https://altinn.no/ui/DelegationRequest',
+    other: 'https://tt02.altinn.no/ui/DelegationRequest'
+});
 
 export const beOmTilgangIAltinnLink = (
     orgnr: string,
@@ -69,27 +72,10 @@ export const beOmTilgangIAltinnLink = (
     serviceEditionKode: string,
     serviceEditionKodeTest?: string
 ) => {
-    if (environment.MILJO === 'prod-sbs') {
-        return (
-            'https://altinn.no/ui/DelegationRequest?offeredBy=' +
-            orgnr +
-            '&resources=' +
-            serviceKode +
-            '_' +
-            serviceEditionKode
-        );
-    } else {
-        let testServiceEditionKode = serviceEditionKode;
-        if (serviceEditionKodeTest) {
-            testServiceEditionKode = serviceEditionKodeTest;
-        }
-        return (
-            'https://tt02.altinn.no/ui/DelegationRequest?offeredBy=' +
-            orgnr +
-            '&resources=' +
-            serviceKode +
-            '_' +
-            testServiceEditionKode
-        );
-    }
+    const edition = gittMiljø({
+        prod: serviceEditionKode,
+        other: serviceEditionKodeTest ?? serviceEditionKode
+    });
+
+    return `${delegationRequestUrl}?offeredBy=${orgnr}&resources=${serviceKode}_${edition}`;
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import 'unorm/lib/unorm';
 import 'whatwg-fetch';
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
 import App from './App/App';
-import environment from './utils/environment';
+import { gittMiljø } from './utils/environment';
 
 Sentry({
     dsn: 'https://037b93dd39294cddb53ee3d9fad4727c@sentry.gc.nav.no/12',
@@ -15,7 +15,13 @@ Sentry({
     environment: window.location.hostname,
 });
 
-if (process.env.REACT_APP_MOCK || environment.MILJO === 'labs-gcp') {
+const kjørerLabs = gittMiljø({
+    prod: false,
+    labs: true,
+    other: false
+})
+
+if (process.env.REACT_APP_MOCK || kjørerLabs) {
     console.log('==========================================');
     console.log('=============== MED MOCK =================');
     console.log('=== DETTE SKAL DU IKKE SE I PRODUKSJON ===');

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,7 +1,41 @@
-const environment = () => {
-    return {
-        MILJO: (window as any)?.appSettings?.MILJO ?? 'local'
-    };
+
+interface Environment {
+    MILJO: string;
+}
+
+export const environment: Environment = {
+    MILJO: (window as any)?.appSettings?.MILJO ?? 'local'
 };
 
-export default environment();
+interface GittMiljø<T> {
+    prod: T;
+    dev?: T;
+    labs?: T;
+    other?: T;
+}
+
+const PROD_REGEX = /^prod-.*/.compile()
+const DEV_REGEX = /^dev-.*/.compile()
+const LABS_REGEX = /^labs-.*/.compile()
+
+export const gittMiljø = <T>(valg: GittMiljø<T>): T => {
+    const miljø = environment.MILJO;
+    if (miljø.match(PROD_REGEX)) {
+        return valg.prod;
+    }
+
+    if (miljø.match(DEV_REGEX) && valg.dev !== undefined) {
+        return valg.dev;
+    }
+
+    if (miljø.match(LABS_REGEX) && valg.labs !== undefined) {
+        return valg.labs;
+    }
+
+    if (valg.other !== undefined) {
+        return valg.other;
+    }
+
+    console.error(`gittMiljø: ingen valgmuligheter for '${miljø}'`)
+    return undefined as any
+}


### PR DESCRIPTION
Forarbeid for migrering til gcp.

Endrer koden slik at den ikke bruker cluster-navn i koden. Bytter det ut med en avhengighet på miljø.

Fjerner http-proxy i express-serveren som ikke brukes.