### PR TITLE
ta i bruk esm import nå som det er fikset i winston

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "server",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -14,9 +13,9 @@
         "jsdom": "^16.7.0",
         "mustache-express": "^1.3.2",
         "node-fetch": "^3.1.1",
-        "prom-client": "^12.0.0",
+        "prom-client": "^13.2.0",
         "prometheus-api-metrics": "^3.2.0",
-        "winston": "^3.4.0"
+        "winston": "3.4.0"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -1301,9 +1300,9 @@
       }
     },
     "node_modules/prom-client": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
-      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.2.0.tgz",
+      "integrity": "sha512-wGr5mlNNdRNzEhRYXgboUU2LxHWIojxscJKmtG3R8f4/KiWqyYgXTLHs0+Ted7tG3zFT7pgHJbtomzZ1L0ARaQ==",
       "dependencies": {
         "tdigest": "^0.1.1"
       },
@@ -2797,9 +2796,9 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prom-client": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
-      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.2.0.tgz",
+      "integrity": "sha512-wGr5mlNNdRNzEhRYXgboUU2LxHWIojxscJKmtG3R8f4/KiWqyYgXTLHs0+Ted7tG3zFT7pgHJbtomzZ1L0ARaQ==",
       "requires": {
         "tdigest": "^0.1.1"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "jsdom": "^16.7.0",
     "mustache-express": "^1.3.2",
     "node-fetch": "^3.1.1",
-    "prom-client": "^12.0.0",
+    "prom-client": "^13.2.0",
     "prometheus-api-metrics": "^3.2.0",
     "winston": "3.4.0"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -3,11 +3,11 @@ import fetch from 'node-fetch';
 import express from 'express';
 import mustacheExpress from 'mustache-express';
 import httpProxyMiddleware from "http-proxy-middleware";
+import {createLogger, transports, format} from 'winston';
 import jsdom from "jsdom";
 import Prometheus from "prom-client";
 import require from "./esm-require.js";
 
-const {createLogger, transports, format} = require('winston');
 const apiMetricsMiddleware = require('prometheus-api-metrics');
 const {JSDOM} = jsdom;
 const {createProxyMiddleware} = httpProxyMiddleware;

--- a/server/start.sh
+++ b/server/start.sh
@@ -1,14 +1,3 @@
 #!/usr/bin/env sh
 
-if test -d /var/run/secrets/nais.io/vault;
-then
-    for FILE in /var/run/secrets/nais.io/vault/*.env
-    do
-        for line in $(cat $FILE); do
-            echo "- exporting `echo $line | cut -d '=' -f 1`"
-            export $line
-        done
-    done
-fi
-
-exec node --experimental-modules server.js
+exec node server.js


### PR DESCRIPTION
i tillegg:
- fjernet --experimental-modules flagget siden Dockerfile nå kjører med node:16
- bumpet prom api og client pga deprecation warning:
```
(node:22932) [DEP0152] DeprecationWarning: Custom PerformanceEntry accessors are deprecated. Please use the detail property.
    at PerformanceObserver.<anonymous> (.../node_modules/prom-client/lib/metrics/gc.js:42:38)
```

re:
- https://github.com/winstonjs/winston/releases/tag/v3.4.0
- https://github.com/winstonjs/winston/pull/2006