### PR TITLE
Fjern team fra spec.

### DIFF
--- a/naiserator.yaml
+++ b/naiserator.yaml
@@ -7,7 +7,6 @@ metadata:
     team: fager
 spec:
   image: {{image}}
-  team: fager
   port: 3000
   ingresses:
     - '{{{ingress}}}'


### PR DESCRIPTION
Team er ikke en del av spec, men av metadata, hvor den allerede er.