### PR TITLE
Fiks endepunkt for rettigheter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-
+*   @navikt/arbeidsforhold

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -12,10 +12,10 @@ jobs:
     name: Bygg
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
           registry-url: https://npm.pkg.github.com/
@@ -31,12 +31,12 @@ jobs:
 
       - run: yarn build
 
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         with:
           context: .
           push: true
@@ -52,7 +52,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     needs: bygg
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Deploy til dev-gcp
         uses: nais/deploy/actions/deploy@v1

--- a/.github/workflows/manual-deploy-dev.yml
+++ b/.github/workflows/manual-deploy-dev.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Sjekk ut kode
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Deploy til dev-gcp
         uses: nais/deploy/actions/deploy@v1

--- a/.github/workflows/manual-deploy-prod.yml
+++ b/.github/workflows/manual-deploy-prod.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Sjekk ut kode
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Deploy til prod-gcp
         uses: nais/deploy/actions/deploy@v1

--- a/src/App/lenker.tsx
+++ b/src/App/lenker.tsx
@@ -22,7 +22,7 @@ export const hentOrganisasjonerLink = () => {
 };
 
 export const hentRettigheterTilAltinnTjenesteLink = () => {
-    return landingsURL + 'arbeidsgiver-arbeidsforhold/api/rettigheter-til-tjeneste/';
+    return landingsURL + 'arbeidsgiver-arbeidsforhold/api/rettigheter-til-tjeneste';
 };
 
 export const sjekkInnloggetLenke = () => {


### PR DESCRIPTION
Etter en oppgradering av backenden har støtte for
"trailing slash" blitt strengere, som betyr at vi enten må eksplisitt gjøre backenden mindre streng, eller endre frontenden til å gå til den "korrekte" url'en.

Her velger vi det sistnevnte