### PR TITLE
Fiks login i demo app

### DIFF
--- a/server/mock/all.cjs
+++ b/server/mock/all.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-    mockAll: (app) => {
+    mockAll: (app, fetch) => {
         require('./aaregMock.cjs').mock(app);
         require('./altinnMock.cjs').mock(app);
         require('./arbeidsforholdMock.cjs').mock(app);

--- a/server/server.js
+++ b/server/server.js
@@ -84,7 +84,7 @@ if (MILJO === 'local' || MILJO === 'demo') {
     applyNotifikasjonMockMiddleware({app, path: '/arbeidsforhold/notifikasjon-bruker-api'});
 
     // mocks:
-    require('./mock/all.cjs').mockAll(app);
+    require('./mock/all.cjs').mockAll(app, fetch);
 } else {
     app.use(
         '/arbeidsforhold/notifikasjon-bruker-api',


### PR DESCRIPTION
Ser ut som demo appen ikke klarer å mocke inlogging, og det derfor blir en feil i klienten når man trykker på login knappen:
Dette har fungert før, så kan ha sklidd ut ifbm transitive endringer over tid.

Appen bør nok få et løft mtp baseimage og avhengigheter. Si gjerne ifra hvis dere ønsker bistand på dette.

Stacktrace:
```
 /usr/src/app/server/mock/all.cjs:20
             const response = await fetch('https://fakedings.intern.dev.nav.no/fake/custom', {
                              ^

 ReferenceError: fetch is not defined
     at /usr/src/app/server/mock/all.cjs:20:30
     at Layer.handle [as handle_request] (/usr/src/app/server/node_modules/express/lib/router/layer.js:95:5)
     at next (/usr/src/app/server/node_modules/express/lib/router/route.js:137:13)
     at Route.dispatch (/usr/src/app/server/node_modules/express/lib/router/route.js:112:3)
     at Layer.handle [as handle_request] (/usr/src/app/server/node_modules/express/lib/router/layer.js:95:5)
     at /usr/src/app/server/node_modules/express/lib/router/index.js:281:22
     at Function.process_params (/usr/src/app/server/node_modules/express/lib/router/index.js:341:12)
     at next (/usr/src/app/server/node_modules/express/lib/router/index.js:275:10)
     at ExpressMiddleware.middleware (/usr/src/app/server/node_modules/prometheus-api-metrics/src/express-middleware.js:124:16)
     at Layer.handle [as handle_request] (/usr/src/app/server/node_modules/express/lib/router/layer.js:95:5)****
```

Klient:
![image](https://github.com/user-attachments/assets/99115b1e-6d81-4616-9ac6-5c8f447440b2)
