### PR TITLE
fjern localhost i redirect i demo

### DIFF
--- a/server/mock/all.cjs
+++ b/server/mock/all.cjs
@@ -27,7 +27,7 @@ module.exports = {
             const token = await response.text()
             res.cookie("selvbetjening-idtoken", token)
             console.log(`login: setter selvbetjening-idtoken til ${token}`)
-            res.redirect("http://localhost:3000/arbeidsforhold/");
+            res.redirect("/arbeidsforhold/");
         });
     }
 }


### PR DESCRIPTION
fikser en bug i redirect knappen når brukt i demo miljø på gcp