### PR TITLE
Oppdaterer @navikt/arbeidsgiver-notifikasjon-widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@grafana/faro-web-sdk": "1.18.2",
     "@navikt/aksel-icons": "^7.24.0",
     "@navikt/arbeidsforhold": "4.1.3",
-    "@navikt/arbeidsgiver-notifikasjon-widget": "8.0.0",
+    "@navikt/arbeidsgiver-notifikasjon-widget": "8.0.2",
     "@navikt/bedriftsmeny": "8.0.3",
     "@navikt/ds-css": "^7.24.0",
     "@navikt/ds-react": "^7.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 4.1.3
         version: 4.1.3(@navikt/aksel-icons@7.24.0)(@navikt/ds-css@7.24.0)(@navikt/ds-react@7.24.0(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@navikt/fnrvalidator@2.1.5)(@react-pdf/renderer@3.4.4(react@18.3.1))(classnames@2.5.1)(dayjs@1.11.13)(lodash.throttle@4.1.1)(react-dom@18.3.1(react@18.3.1))(react-modal@3.16.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@navikt/arbeidsgiver-notifikasjon-widget':
-        specifier: 8.0.0
-        version: 8.0.0(@navikt/aksel-icons@7.24.0)(@navikt/ds-css@7.24.0)(@navikt/ds-react@7.24.0(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@navikt/nav-dekoratoren-moduler@3.2.3(csp-header@6.1.0)(html-react-parser@5.2.5(@types/react@18.3.1)(react@18.3.1))(jsdom@26.1.0)(react@18.3.1))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 8.0.2
+        version: 8.0.2(@navikt/aksel-icons@7.24.0)(@navikt/ds-css@7.24.0)(@navikt/ds-react@7.24.0(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@navikt/nav-dekoratoren-moduler@3.2.3(csp-header@6.1.0)(html-react-parser@5.2.5(@types/react@18.3.1)(react@18.3.1))(jsdom@26.1.0)(react@18.3.1))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@navikt/bedriftsmeny':
         specifier: 8.0.3
         version: 8.0.3(@navikt/ds-css@7.24.0)(@navikt/ds-react@7.24.0(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react-dom@18.3.1)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react-router@7.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -1071,8 +1071,8 @@ packages:
       react: '18'
       react-modal: '3'
 
-  '@navikt/arbeidsgiver-notifikasjon-widget@8.0.0':
-    resolution: {integrity: sha512-JyRYO3oJPE9MIjzBI8uNKgqmWnoLXr+nyX9AnF/ivnGzeDryW9/OiIy1tsPsKleQU9Bd9ptvv96po9PUlIrYWw==, tarball: https://npm.pkg.github.com/download/@navikt/arbeidsgiver-notifikasjon-widget/8.0.0/887b296e398cadff9b9d56dda815f935e28ab57a}
+  '@navikt/arbeidsgiver-notifikasjon-widget@8.0.2':
+    resolution: {integrity: sha512-eCEyVvAqMm1WgdZm2v0BpRbm7LoUdqWALeJMk0mEuL/SYjrO2Xu6FNnw9frijTs/v9P8/9BzuAw26cLs8Tgljw==, tarball: https://npm.pkg.github.com/download/@navikt/arbeidsgiver-notifikasjon-widget/8.0.2/c4d8ff07ee8d2b18c64dff54f9f258f1ba09ee23}
     peerDependencies:
       '@navikt/aksel-icons': '>=7.21.1'
       '@navikt/ds-css': '>=7.21.1'
@@ -4991,7 +4991,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@navikt/arbeidsgiver-notifikasjon-widget@8.0.0(@navikt/aksel-icons@7.24.0)(@navikt/ds-css@7.24.0)(@navikt/ds-react@7.24.0(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@navikt/nav-dekoratoren-moduler@3.2.3(csp-header@6.1.0)(html-react-parser@5.2.5(@types/react@18.3.1)(react@18.3.1))(jsdom@26.1.0)(react@18.3.1))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@navikt/arbeidsgiver-notifikasjon-widget@8.0.2(@navikt/aksel-icons@7.24.0)(@navikt/ds-css@7.24.0)(@navikt/ds-react@7.24.0(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@navikt/nav-dekoratoren-moduler@3.2.3(csp-header@6.1.0)(html-react-parser@5.2.5(@types/react@18.3.1)(react@18.3.1))(jsdom@26.1.0)(react@18.3.1))(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@apollo/client': 3.13.8(@types/react@18.3.1)(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@navikt/aksel-icons': 7.24.0


### PR DESCRIPTION
Oppdaterer `@navikt/arbeidsgiver-notifikasjon-widget` til versjon `8.0.2` dette fikser feilmeldingen:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'T')
    at A2.flushSync (Dropdown-DP1OZzor.js:315:17)
    at xt (Dropdown-DP1OZzor.js:1208:55)
    at c7 (Dropdown-DP1OZzor.js:1235:9)
    at HTMLDocument.s5 (Dropdown-DP1OZzor.js:1239:13)
```